### PR TITLE
fix: replace JSONObject quote method with a proper String escape method

### DIFF
--- a/src/main/java/me/micartey/webhookly/JSONObject.java
+++ b/src/main/java/me/micartey/webhookly/JSONObject.java
@@ -25,10 +25,10 @@ public class JSONObject {
         int i = 0;
         for (Map.Entry<String, Object> entry : entrySet) {
             Object val = entry.getValue();
-            builder.append(quote(entry.getKey())).append(":");
+            builder.append(escape(entry.getKey())).append(":");
 
             if (val instanceof String) {
-                builder.append(quote(String.valueOf(val)));
+                builder.append(escape(String.valueOf(val)));
             } else if (val instanceof Integer) {
                 builder.append(Integer.valueOf(String.valueOf(val)));
             } else if (val instanceof Boolean) {
@@ -50,7 +50,27 @@ public class JSONObject {
         return builder.toString();
     }
 
-    private String quote(String string) {
-        return "\"" + string + "\"";
+    private String escape(String string) {
+        StringBuilder builder = new StringBuilder("\"");
+        for (char c : string.toCharArray()) {
+            if (c == '\\' || c == '"' || c == '/') {
+                builder.append("\\").append(c);
+            } else if (c == '\b') {
+                builder.append("\\b");
+            } else if (c == '\t') {
+                builder.append("\\t");
+            } else if (c == '\n') {
+                builder.append("\\n");
+            } else if (c == '\f') {
+                builder.append("\\f");
+            } else if (c == '\r') {
+                builder.append("\\r");
+            } else if (c < ' ' || c > 0x7f) {
+                builder.append(String.format("\\u%04x", (int) c));
+            } else {
+                builder.append(c);
+            }
+        }
+        return builder.append('"').toString();
     }
 }


### PR DESCRIPTION
I did this because I ran into some problems when trying to pass a String value to a field. I thought about using switch expressions, but since source compatibility is in Java 8 I opted to use else-if blocks. Let me know if there is anything that can be improved.